### PR TITLE
Support profile-only to cluster update

### DIFF
--- a/senlinclient/tests/unit/v1/test_cluster.py
+++ b/senlinclient/tests/unit/v1/test_cluster.py
@@ -294,6 +294,7 @@ class TestClusterUpdate(TestCluster):
         },
         "name": 'new_cluster',
         "profile_id": 'new_profile',
+        "profile_only": False,
         "timeout": "30"
     }
 

--- a/senlinclient/tests/unit/v1/test_shell.py
+++ b/senlinclient/tests/unit/v1/test_shell.py
@@ -955,6 +955,7 @@ class ShellTest(testtools.TestCase):
         service = mock.Mock()
         args = {
             'profile': 'test_profile',
+            'profile_only': 'false',
             'name': 'CLUSTER1',
             'metadata': ['user=demo'],
             'timeout': 100,
@@ -962,6 +963,7 @@ class ShellTest(testtools.TestCase):
         attrs = copy.deepcopy(args)
         attrs['metadata'] = {'user': 'demo'}
         attrs['profile_id'] = 'test_profile'
+        attrs['profile_only'] = False
         del attrs['profile']
         args = self._make_args(args)
         args.id = 'CID'

--- a/senlinclient/v1/cluster.py
+++ b/senlinclient/v1/cluster.py
@@ -18,6 +18,7 @@ import sys
 import threading
 import time
 
+from oslo_utils import strutils
 from openstack import exceptions as sdk_exc
 from osc_lib.command import command
 from osc_lib import exceptions as exc
@@ -230,6 +231,15 @@ class UpdateCluster(command.ShowOne):
             help=_('ID or name of new profile to use')
         )
         parser.add_argument(
+            '--profile-only',
+            default=False, metavar='<boolean>',
+            help=_("Whether the cluster should be updated profile only. "
+                   "If false, it will be applied to all existing nodes. "
+                   "If true, any newly created nodes will use the new profile,"
+                   "but existing nodes will not be changed. Default is False.")
+
+        )
+        parser.add_argument(
             '--timeout',
             metavar='<timeout>',
             help=_('New timeout (in seconds) value for the cluster')
@@ -264,6 +274,10 @@ class UpdateCluster(command.ShowOne):
         attrs = {
             'name': parsed_args.name,
             'profile_id': parsed_args.profile,
+            'profile_only': strutils.bool_from_string(
+                parsed_args.profile_only,
+                strict=True,
+            ),
             'metadata': senlin_utils.format_parameters(parsed_args.metadata),
             'timeout': parsed_args.timeout,
         }

--- a/senlinclient/v1/shell.py
+++ b/senlinclient/v1/shell.py
@@ -778,7 +778,12 @@ def do_cluster_run(service, args):
 
 
 @utils.arg('-p', '--profile', metavar='<PROFILE>',
-           help=_('ID of new profile to use.'))
+           help=_('ID or name of new profile to use.'))
+@utils.arg('-P', '--profile-only', metavar='<BOOLEAN>', default=False,
+           help=_("Whether the cluster should be updated profile only. "
+                  "If false, it will be applied to all existing nodes. "
+                  "If true, any newly created nodes will use the new profile, "
+                  "but existing nodes will not be changed. Default is False."))
 @utils.arg('-t', '--timeout', metavar='<TIMEOUT>',
            help=_('New timeout (in seconds) value for the cluster.'))
 @utils.arg('-M', '--metadata', metavar='<KEY1=VALUE1;KEY2=VALUE2...>',
@@ -797,6 +802,9 @@ def do_cluster_update(service, args):
     attrs = {
         'name': args.name,
         'profile_id': args.profile,
+        'profile_only': strutils.bool_from_string(
+            args.profile_only, strict=True
+        ),
         'metadata': utils.format_parameters(args.metadata),
         'timeout': args.timeout,
     }


### PR DESCRIPTION
This path revises cluster-update command.
The command could support 'profile-only' parameter.
partial-blueprint: add-profile-only-to-cluster-update

Change-Id: Ibf2e4d67abe76b92a508a3e22e5c528d53cde5a4
Signed-off-by: chohoor <chohoor@gmail.com>
(cherry picked from commit 06b91c77128957d3fccccfb613dce2e989f868b3)