### PR TITLE
Fix list of event with timestamp field

### DIFF
--- a/senlinclient/tests/unit/v1/test_event.py
+++ b/senlinclient/tests/unit/v1/test_event.py
@@ -29,8 +29,8 @@ class TestEvent(fakes.TestClusteringv1):
 
 class TestEventList(TestEvent):
 
-    columns = ['id', 'timestamp', 'obj_type', 'obj_id', 'obj_name', 'action',
-               'status', 'status_reason', 'level']
+    columns = ['id', 'generated_at', 'obj_type', 'obj_id', 'obj_name',
+               'action', 'status', 'status_reason', 'level']
 
     response = {"events": [
         {
@@ -44,7 +44,7 @@ class TestEventList(TestEvent):
             "project": "6e18cc2bdbeb48a5b3cad2dc499f6804",
             "status": "CREATING",
             "status_reason": "Initializing",
-            "timestamp": "2015-03-05T08:53:15",
+            "generated_at": "2015-03-05T08:53:15",
             "user": "a21ded6060534d99840658a777c2af5a"
         }
     ]}
@@ -145,7 +145,7 @@ class TestEventShow(TestEvent):
         "project": "6e18cc2bdbeb48a5b3cad2dc499f6804",
         "status": "CREATING",
         "status_reason": "Initializing",
-        "timestamp": "2015-03-05T08:53:15",
+        "generated_at": "2015-03-05T08:53:15",
         "user": "a21ded6060534d99840658a777c2af5a"
     }}
 

--- a/senlinclient/tests/unit/v1/test_shell.py
+++ b/senlinclient/tests/unit/v1/test_shell.py
@@ -1545,8 +1545,10 @@ class ShellTest(testtools.TestCase):
     @mock.patch.object(utils, 'print_list')
     def test_do_event_list(self, mock_print):
         service = mock.Mock()
-        fields = ['id', 'timestamp', 'obj_type', 'obj_id', 'obj_name',
+        fields = ['id', 'generated_at', 'obj_type', 'obj_id', 'obj_name',
                   'action', 'status', 'level', 'cluster_id']
+        field_labels = ['id', 'timestamp', 'obj_type', 'obj_id', 'obj_name',
+                        'action', 'status', 'level', 'cluster_id']
 
         args = {
             'sort': 'timestamp:asc',
@@ -1571,7 +1573,8 @@ class ShellTest(testtools.TestCase):
         service.events.assert_called_once_with(**queries)
         mock_print.assert_called_once_with(events, fields,
                                            formatters=formatters,
-                                           sortby_index=sortby_index)
+                                           sortby_index=sortby_index,
+                                           field_labels=field_labels)
 
     @mock.patch.object(utils, 'print_dict')
     def test_do_event_show(self, mock_print):

--- a/senlinclient/v1/event.py
+++ b/senlinclient/v1/event.py
@@ -79,7 +79,7 @@ class ListEvent(command.Lister):
         self.log.debug("take_action(%s)", parsed_args)
 
         senlin_client = self.app.client_manager.clustering
-        columns = ['id', 'timestamp', 'obj_type', 'obj_id', 'obj_name',
+        columns = ['id', 'generated_at', 'obj_type', 'obj_id', 'obj_name',
                    'action', 'status', 'status_reason', 'level']
         queries = {
             'sort': parsed_args.sort,

--- a/senlinclient/v1/shell.py
+++ b/senlinclient/v1/shell.py
@@ -1545,8 +1545,11 @@ def do_receiver_delete(service, args):
 def do_event_list(service, args):
     """List events."""
     show_deprecated('senlin event-list', 'openstack cluster event list')
-    fields = ['id', 'timestamp', 'obj_type', 'obj_id', 'obj_name', 'action',
+    fields = ['id', 'generated_at', 'obj_type', 'obj_id', 'obj_name', 'action',
               'status', 'level', 'cluster_id']
+
+    field_labels = ['id', 'timestamp', 'obj_type', 'obj_id', 'obj_name',
+                    'action', 'status', 'level', 'cluster_id']
 
     queries = {
         'sort': args.sort,
@@ -1569,7 +1572,7 @@ def do_event_list(service, args):
 
     events = service.events(**queries)
     utils.print_list(events, fields, formatters=formatters,
-                     sortby_index=sortby_index)
+                     sortby_index=sortby_index, field_labels=field_labels)
 
 
 @utils.arg('id', metavar='<EVENT>',


### PR DESCRIPTION
The SDK will rename timestamp field to 'generated_at'. This patch adapts
the event list to make it work.

Change-Id: Ibefaebcdb4ee4d1b556739992ab59642f9c221e0
(cherry picked from commit ba61a17055ab5088180973e79e88caadc5b2c637)

Bug-ES #10079
http://192.168.15.2/issues/10079