### PR TITLE
Fix profile list

### DIFF
--- a/senlinclient/tests/unit/v1/test_shell.py
+++ b/senlinclient/tests/unit/v1/test_shell.py
@@ -120,7 +120,7 @@ class ShellTest(testtools.TestCase):
         service = mock.Mock()
         profiles = mock.Mock()
         service.profiles.return_value = profiles
-        fields = ['id', 'name', 'type_name', 'created_at']
+        fields = ['id', 'name', 'type', 'created_at']
         args = {
             'limit': 20,
             'marker': 'mark_id',

--- a/senlinclient/v1/shell.py
+++ b/senlinclient/v1/shell.py
@@ -106,7 +106,7 @@ def do_profile_type_show(service, args):
 def do_profile_list(service, args=None):
     """List profiles that meet the criteria."""
     show_deprecated('senlin profile-list', 'openstack cluster profile list')
-    fields = ['id', 'name', 'type_name', 'created_at']
+    fields = ['id', 'name', 'type', 'created_at']
     queries = {
         'limit': args.limit,
         'marker': args.marker,


### PR DESCRIPTION
Change field 'type_name' to 'type' in profile list, because 'type'
is used on openstacksdk side, use 'type_name' made type field show
noting when running 'senlin profile-list'.

Change-Id: I78c7f2e2f3e855964d0883927489dc7127206f9b
(cherry picked from commit 738c0527d5767aab00b74869508b1592312ce4e2)

Bug-ES #10081
http://192.168.15.2/issues/10081