### PR TITLE
remove redundant value when cluster-show

### DIFF
--- a/senlinclient/v1/cluster.py
+++ b/senlinclient/v1/cluster.py
@@ -140,6 +140,8 @@ def _show_cluster(senlin_client, cluster_id):
         'node_ids': senlin_utils.list_formatter
     }
     data = cluster.to_dict()
+    if 'is_profile_only' in data:
+        data.pop('is_profile_only')
     columns = sorted(data.keys())
     return columns, utils.get_dict_properties(data, columns,
                                               formatters=formatters)

--- a/senlinclient/v1/shell.py
+++ b/senlinclient/v1/shell.py
@@ -505,7 +505,9 @@ def _show_cluster(service, cluster_id):
         'metadata': utils.json_formatter,
         'node_ids': utils.list_formatter,
     }
-    utils.print_dict(cluster.to_dict(), formatters=formatters)
+    cluster_attrs = cluster.to_dict()
+    cluster_attrs.pop('is_profile_only')
+    utils.print_dict(cluster_attrs, formatters=formatters)
 
 
 @utils.arg('-p', '--profile', metavar='<PROFILE>', required=True,


### PR DESCRIPTION
cluster-show command returned a redundant value named is_profile_only,
this path removed the redundant value because it is not a attr belong
to cluster.

Change-Id: Ic11d0b8ea8eb07a0bbe3b3e125b1ba7d34663784
Closes-Bug: #1693156