### PR TITLE
Support  receiver update operation

### DIFF
--- a/senlinclient/tests/unit/v1/test_receiver.py
+++ b/senlinclient/tests/unit/v1/test_receiver.py
@@ -17,6 +17,7 @@ import six
 from openstack.cluster.v1 import receiver as sdk_receiver
 from openstack import exceptions as sdk_exc
 from osc_lib import exceptions as exc
+from osc_lib import utils
 
 from senlinclient.common.i18n import _
 from senlinclient.tests.unit.v1 import fakes
@@ -261,6 +262,64 @@ class TestReceiverCreate(TestReceiver):
         args['cluster_id'] = None
         args['action'] = None
         self.mock_client.create_receiver.assert_called_with(**args)
+
+
+class TestReceiverUpdate(TestReceiver):
+    args = {
+        "action": "CLUSTER_SCALE_OUT",
+        "name": "test_receiver",
+        "params": {
+            "count": "2"
+        },
+    }
+
+    def setUp(self):
+        super(TestReceiverUpdate, self).setUp()
+        self.cmd = osc_receiver.UpdateReceiver(self.app, None)
+        fake_receiver = mock.Mock(
+            action="CLUSTER_SCALE_IN",
+            actor={},
+            channel={
+                "alarm_url": "http://node1:8778/v1/webhooks/e03dd2e5-8f2e-4ec1"
+                             "-8c6a-74ba891e5422/trigger?V=1&count=1"
+            },
+            created_at="2015-06-27T05:09:43",
+            domain_id="Default",
+            id="573aa1ba-bf45-49fd-907d-6b5d6e6adfd3",
+            params={"count": "1"},
+            project_id="6e18cc2bdbeb48a5b3cad2dc499f6804",
+            updated_at=None,
+            user_id="b4ad2d6e18cc2b9c48049f6dbe8a5b3c"
+        )
+        fake_receiver.name = "cluster_inflate"
+        fake_receiver.action = "CLUSTER_SCALE_IN"
+        fake_receiver.params = {"count": "1"}
+        fake_receiver.to_dict = mock.Mock(return_value={})
+        self.mock_client.update_receiver = mock.Mock(
+            return_value=fake_receiver)
+        self.mock_client.get_receiver = mock.Mock(return_value=fake_receiver)
+        self.mock_client.find_receiver = mock.Mock(return_value=fake_receiver)
+        utils.get_dict_properties = mock.Mock(return_value='')
+
+    def test_receiver_update_defaults(self):
+        arglist = ['--name', 'test_receiver', '--action', 'CLUSTER_SCALE_OUT',
+                   '--params', 'count=2', '573aa1ba']
+        parsed_args = self.check_parser(self.cmd, arglist, [])
+
+        self.cmd.take_action(parsed_args)
+
+        self.mock_client.update_receiver.assert_called_with(
+            "573aa1ba-bf45-49fd-907d-6b5d6e6adfd3", **self.args)
+
+    def test_receiver_update_not_found(self):
+        arglist = ['--name', 'test_receiver', '--action', 'CLUSTER_SCALE_OUT',
+                   '--params', 'count=2', '573aa1b2']
+        parsed_args = self.check_parser(self.cmd, arglist, [])
+        self.mock_client.find_receiver.return_value = None
+        error = self.assertRaises(exc.CommandError,
+                                  self.cmd.take_action,
+                                  parsed_args)
+        self.assertIn('Receiver not found: 573aa1b2', str(error))
 
 
 class TestReceiverDelete(TestReceiver):

--- a/senlinclient/tests/unit/v1/test_shell.py
+++ b/senlinclient/tests/unit/v1/test_shell.py
@@ -536,6 +536,30 @@ class ShellTest(testtools.TestCase):
         service.create_receiver.assert_called_once_with(**params)
         mock_show.assert_called_once_with(service, 'FAKE_ID')
 
+    @mock.patch.object(sh, '_show_receiver')
+    def test_do_receiver_update(self, mock_show):
+        service = mock.Mock()
+        args = {
+            'name': 'receiver2',
+            'id': 'receiver_id',
+            'action': 'CLUSTER_SCALE_OUT',
+            'params': {'count': '2'}
+        }
+        args = self._make_args(args)
+        params = {
+            'name': 'receiver2',
+            'action': 'CLUSTER_SCALE_OUT',
+            'params': {'count': '2'}
+        }
+        receiver = mock.Mock()
+        receiver.id = 'receiver_id'
+        service.get_receiver.return_value = receiver
+        sh.do_receiver_update(service, args)
+        service.get_receiver.assert_called_once_with('receiver_id')
+        service.update_receiver.assert_called_once_with(
+            receiver, **params)
+        mock_show(service, receiver_id=receiver.id)
+
     def test_do_receiver_delete(self):
         service = mock.Mock()
         args = {'id': ['FAKE']}

--- a/senlinclient/v1/client.py
+++ b/senlinclient/v1/client.py
@@ -425,6 +425,14 @@ class Client(object):
         """
         return self.service.get_receiver(receiver)
 
+    def update_receiver(self, receiver, **attrs):
+        """Update receiver
+
+        Doc link:
+        http://developer.openstack.org/api-ref-clustering-v1.html#updateReceiver
+        """
+        return self.service.update_receiver(receiver, **attrs)
+
     def delete_receiver(self, receiver, ignore_missing=True):
         """Delete receiver
 

--- a/senlinclient/v1/receiver.py
+++ b/senlinclient/v1/receiver.py
@@ -205,6 +205,57 @@ class CreateReceiver(command.ShowOne):
         return _show_receiver(senlin_client, receiver.id)
 
 
+class UpdateReceiver(command.ShowOne):
+    """Create a receiver."""
+
+    log = logging.getLogger(__name__ + ".UpdateReceiver")
+
+    def get_parser(self, prog_name):
+        parser = super(UpdateReceiver, self).get_parser(prog_name)
+
+        parser.add_argument(
+            '--name',
+            metavar='<name>',
+            help=_('Name of the receiver to create')
+        )
+        parser.add_argument(
+            '--action',
+            metavar='<action>',
+            help=_('Name or ID of the targeted action to be triggered. '
+                   'Required if receiver type is webhook')
+        )
+        parser.add_argument(
+            '--params',
+            metavar='<"key1=value1;key2=value2...">',
+            help=_('A dictionary of parameters that will be passed to target '
+                   'action when the receiver is triggered'),
+            action='append'
+        )
+        parser.add_argument(
+            'receiver',
+            metavar='<receiver>',
+            help=_('Name or ID of receiver(s) to update')
+        )
+        return parser
+
+    def take_action(self, parsed_args):
+        self.log.debug("take_action(%s)", parsed_args)
+
+        senlin_client = self.app.client_manager.clustering
+        params = {
+            'name': parsed_args.name,
+            'action': parsed_args.action,
+            'params': senlin_utils.format_parameters(parsed_args.params)
+        }
+
+        receiver = senlin_client.find_receiver(parsed_args.receiver)
+        if receiver is None:
+            raise exc.CommandError(_('Receiver not found: %s') %
+                                   parsed_args.receiver)
+        senlin_client.update_receiver(receiver.id, **params)
+        return _show_receiver(senlin_client, receiver_id=receiver.id)
+
+
 class DeleteReceiver(command.Command):
     """Delete receiver(s)."""
 

--- a/senlinclient/v1/shell.py
+++ b/senlinclient/v1/shell.py
@@ -1490,6 +1490,36 @@ def do_receiver_create(service, args):
     _show_receiver(service, receiver.id)
 
 
+@utils.arg('-n', '--name', metavar='<NAME>',
+           help=_('The new name for the receiver.'))
+@utils.arg('-a', '--action', metavar='<ACTION>',
+           help=_('Name or ID of the targeted action to be triggered. '
+                  'Required if receiver type is webhook.'))
+@utils.arg('-P', '--params', metavar='<"KEY1=VALUE1;KEY2=VALUE2...">',
+           help=_('A dictionary of parameters that will be passed to target '
+                  'action when the receiver is triggered.'),
+           action='append')
+@utils.arg('id', metavar='<receiver>',
+           help=_('Name or ID of receiver to update.'))
+def do_receiver_update(service, args):
+    """Update a receiver."""
+    show_deprecated('senlin receiver-update',
+                    'openstack cluster receiver update')
+    params = {
+        'name': args.name,
+        'action': args.action,
+        'params': args.params
+    }
+
+    # Find the receiver first, we need its id
+    try:
+        receiver = service.get_receiver(args.id)
+    except sdk_exc.ResourceNotFound:
+        raise exc.CommandError(_('Receiver not found: %s') % args.id)
+    service.update_receiver(receiver, **params)
+    _show_receiver(service, receiver.id)
+
+
 @utils.arg('id', metavar='<RECEIVER>', nargs='+',
            help=_('Name or ID of receiver(s) to delete.'))
 def do_receiver_delete(service, args):

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,6 +75,7 @@ openstack.clustering.v1 =
     cluster_profile_update = senlinclient.v1.profile:UpdateProfile
     cluster_profile_validate = senlinclient.v1.profile:ValidateProfile
     cluster_receiver_create = senlinclient.v1.receiver:CreateReceiver
+    cluster_receiver_update = senlinclient.v1.receiver:UpdateReceiver
     cluster_receiver_delete = senlinclient.v1.receiver:DeleteReceiver
     cluster_receiver_list = senlinclient.v1.receiver:ListReceiver
     cluster_receiver_show = senlinclient.v1.receiver:ShowReceiver


### PR DESCRIPTION
This patch add receiver update operation,
Then user cloud run 'receiver-update' command.
use receiver-update change has exist receiver name,action and params.

Implements: blueprint add-receiver-update

Depends-On: I228edd1f5ada5b91e82ef04c95e9a7fa2b7de305
Change-Id: I8adaef75c18b93ec46d95e91f2058f6a4b8d4608
Signed-off-by: Yuanbin.Chen <cybing4@gmail.com>
(cherry picked from commit 79b83d96aeed4f670aca6c102497d630a1772841)

Feature-ES #10376
http://192.168.15.2/issues/10376